### PR TITLE
documentation update for new interface members

### DIFF
--- a/docs-template/publish.js
+++ b/docs-template/publish.js
@@ -111,7 +111,7 @@ const buildItemTypeStrings = (item) =>
   chain(item, `type.names`, []).map(name => linkTo(name, htmlSafe(name))) || [];
 
 const buildAttribsString = (attribs) =>
-  (attribs || []).length && span(htmlSafe(`(${attribs.join(`, `)})`), `attributes`) || ``;
+  (attribs || []).length && span(htmlSafe(`(${attribs.join(`, `)})`)) || ``;
 
 const addNonParamAttributes = (items) => items.map(item => buildItemTypeStrings(item));
 
@@ -143,7 +143,7 @@ const addSignatureTypes = (f) => {
   f.signature = (f.signature || ``).concat(span(types.length && ` :${types}`, `type-signature`));
 }
 
-const addAttribs = (f) => f.attribs = span(buildAttribsString(helper.getAttribs(f)));
+const addAttribs = (f) => f.attribs = span(buildAttribsString(helper.getAttribs(f)), `attributes`);
 
 const shortenPaths = (files, commonPrefix) => {
   Object.keys(files).forEach(file => {
@@ -544,7 +544,6 @@ exports.publish = (taffyData, opts, tutorials) => {
       .forEach(([type, heading]) => {
         const generator = helper.find(type, {longname});
         if (generator.length) {
-          console.log(`Generating`, generator[0].name)
           generate(generator[0].name, heading, generator, helper.longnameToUrl[longname]);
         }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "docs:build": "npm run docs:prepare && npm run docs:api && gitbook build",
         "docs:serve": "npm run docs:prepare && npm run docs:api && gitbook serve",
         "docs:clean": "rimraf _book",
-        "jsdoc:build": "jsdoc -t ./docs-template/ -v src -r -c ./docs-template/jsdoc.json",
+        "jsdoc:build": "jsdoc -t ./docs-template/ src -r -c ./docs-template/jsdoc.json",
         "jsdoc:serve": "http-server ./docs/ -o"
     },
     "dependencies": {

--- a/src/models/ERC20/ERC20TokenLock.js
+++ b/src/models/ERC20/ERC20TokenLock.js
@@ -9,7 +9,7 @@ var assert = require('assert');
 
 /**
  * ERC20 Token Lock Contract Object
- * @constructor ERC20TokenLock
+ * @class ERC20TokenLock
  * @param {Web3} web3
  * @param {Address} tokenAddress
  * @param {Address} contractAddress ? (opt)
@@ -34,16 +34,16 @@ class ERC20TokenLock extends IContract {
 	}
 
 	/**
-	 * @function erc20
+	 * @function
 	 * @description Get ERC20 Address of the Token Contract managed
 	 * @returns {Address}
 	 */
 	async erc20() {
 		return await this.params.contract.getContract().methods.erc20().call();
 	}
-	
+
 	/**
-	 * @function getTokenAmount
+	 * @function
 	 * @description Get Token Amount of ERC20 Address
 	 * @returns {Address}
 	 */
@@ -52,7 +52,7 @@ class ERC20TokenLock extends IContract {
 	};
 
 	/**
-	 * @function totalAmountStaked
+	 * @function
 	 * @description Get All Tokens staked/locked at that specific moment
 	 * @returns {Integer}
 	 */
@@ -62,7 +62,7 @@ class ERC20TokenLock extends IContract {
 	}
 
 	/**
-	 * @function minAmountToLock
+	 * @function
 	 * @description Get minimum amount of tokens to lock per user
 	 * @returns {Integer}
 	 */
@@ -72,7 +72,7 @@ class ERC20TokenLock extends IContract {
 	}
 
 	/**
-	 * @function maxAmountToLock
+	 * @function
 	 * @description Get maximum amount of tokens to lock per user
 	 * @returns {Integer}
 	 */
@@ -82,7 +82,7 @@ class ERC20TokenLock extends IContract {
 	}
 
 	/**
-	 * @function canRelease
+	 * @function
 	 * @description Check if locked tokens release date has come and user can withdraw them
 	 * @returns {Boolean}
 	 */
@@ -91,7 +91,7 @@ class ERC20TokenLock extends IContract {
 	};
 
 	/**
-	 * @function getLockedTokens
+	 * @function
 	 * @description Get locked tokens amount for a given address
 	 * @returns {Integer} amount Locked token amount
 	 */
@@ -101,7 +101,7 @@ class ERC20TokenLock extends IContract {
 	};
 
 	/**
-	 * @function getLockedTokensInfo
+	 * @function
 	 * @description Get locked tokens info for a given address
 	 * @returns {Date} startDate
 	 * @returns {Date} endDate
@@ -109,7 +109,7 @@ class ERC20TokenLock extends IContract {
 	 */
 	getLockedTokensInfo = async ({ address }) => {
 		let res = await this.params.contract.getContract().methods.getLockedTokensInfo(address).call();
-		
+
 		return {
 			startDate: Numbers.fromSmartContractTimeToMinutes(res[0]),
 			endDate: Numbers.fromSmartContractTimeToMinutes(res[1]),
@@ -118,7 +118,7 @@ class ERC20TokenLock extends IContract {
 	};
 
 	/**
-	 * @function setMaxAmountToLock
+	 * @function
 	 * @description Admin sets maximum amount of tokens to lock per user
 	 * @param {Integer} tokenAmount Maximum tokens amount
 	 * @returns {Boolean} Success True if operation was successful
@@ -133,7 +133,7 @@ class ERC20TokenLock extends IContract {
 	};
 
 	/**
-	 * @function setMinAmountToLock
+	 * @function
 	 * @description Admin sets minimum amount of tokens to lock per user
 	 * @param {Integer} tokenAmount Minimum tokens amount
 	 * @returns {Boolean} Success True if operation was successful
@@ -148,7 +148,6 @@ class ERC20TokenLock extends IContract {
 	};
 
 	/**
-	 * @function lock
 	 * @description User locks his tokens until specified end date.
 	 * @param {Integer} amount Tokens amount to be locked
 	 * @param {Date} endDate Lock tokens until this end date
@@ -192,7 +191,7 @@ class ERC20TokenLock extends IContract {
 	};
 
 	/**
-	 * @function release
+	 * @function
 	 * @description User withdraws his locked tokens after specified end date
 	 * @return {Boolean} Success True if operation was successful
 	 */
@@ -202,7 +201,7 @@ class ERC20TokenLock extends IContract {
 		// check if user has locked tokens and if he can unlock and withdraw them
 		let { startDate, endDate, amount } = await this.getLockedTokensInfo({ address: address });
 		let lockedAmount = amount;
-		
+
 		assert(lockedAmount > 0, 'ERC20TokenLock.user has no locked tokens');
 		assert(moment() >= endDate, 'ERC20TokenLock.tokens release date not reached');
 
@@ -210,7 +209,7 @@ class ERC20TokenLock extends IContract {
 	};
 
 	/**
-	 * @function approveERC20Transfer
+	 * @function
 	 * @description Approve this contract to transfer tokens of the ERC20 token contract on behalf of user
 	 * @return {Boolean} Success True if operation was successful
 	 */
@@ -223,9 +222,6 @@ class ERC20TokenLock extends IContract {
 		});
 	};
 
-	/**
-	 * @override
-	 */
 	__assert = async () => {
 		if (!this.getAddress()) {
 			throw new Error('Contract is not deployed, first deploy it and provide a contract address');
@@ -248,8 +244,6 @@ class ERC20TokenLock extends IContract {
 	};
 
 	/**
-	 * @function deploy
-	 * @override
 	 * @description Deploy the ERC20 Token Lock Contract
 	 */
 	deploy = async ({ callback } = {}) => {
@@ -264,7 +258,7 @@ class ERC20TokenLock extends IContract {
 		await this.__assert();
 		return res;
 	};
-	
+
 	getERC20Contract = () => this.params.ERC20Contract;
 }
 

--- a/src/models/ERC721/ERC721Standard.js
+++ b/src/models/ERC721/ERC721Standard.js
@@ -4,7 +4,7 @@ import IContract from '../IContract';
 import ERC20Contract from '../ERC20/ERC20Contract';
 /**
  * ERC721Contract Object
- * @constructor ERC721Contract
+ * @class ERC721Contract
  * @param {Web3} web3
  * @param {Address} contractAddress ? (opt)
  */
@@ -14,9 +14,6 @@ class ERC721Standard extends IContract{
 		super({abi : erc721standard, ...params});
 	}
 
-	  /**
-     * @override 
-     */
 	__assert = async () => {
         if(!this.getAddress()){
             throw new Error("Contract is not deployed, first deploy it and provide a contract address");
@@ -36,19 +33,19 @@ class ERC721Standard extends IContract{
 	}
 
 	/**
-	 * @function exists
-	 * @description Verify if token ID exists 
+	 * @function
+	 * @description Verify if token ID exists
 	 * @returns {Integer} Token Id
 	 */
 	async exists({tokenID}) {
 		return await this.params.contract
 		.getContract()
 		.methods.exists(tokenID)
-		.call();	
+		.call();
 	}
 
 	/**
-	 * @function getURITokenID
+	 * @function
 	 * @description Verify what is the getURITokenID
 	 * @returns {String} URI
 	 */
@@ -59,7 +56,7 @@ class ERC721Standard extends IContract{
 		.call();
 	}
 	/**
-	 * @function baseURI
+	 * @function
 	 * @description Verify what is the baseURI
 	 * @returns {String} URI
 	 */
@@ -71,7 +68,7 @@ class ERC721Standard extends IContract{
 	}
 
 	 /**
-	 * @function setBaseTokenURI
+	 * @function
 	 * @description Set Base Token URI
     */
 	setBaseTokenURI = async ({URI}) => {
@@ -81,8 +78,8 @@ class ERC721Standard extends IContract{
 	}
 
 	/**
-	 * @function mint
-	 * @description Mint created TokenID 
+	 * @function
+	 * @description Mint created TokenID
 	 * @param {Address} to
 	 * @param {Integer} tokenID
 	*/

--- a/src/models/IContract.js
+++ b/src/models/IContract.js
@@ -12,9 +12,9 @@ import _ from 'lodash';
 
 class IContract {
 	constructor({
-    web3, 
-    contractAddress = null /* If not deployed */, 
-    abi, 
+    web3,
+    contractAddress = null /* If not deployed */,
+    abi,
     acc
   }) {
 		try {
@@ -117,7 +117,7 @@ class IContract {
 	};
 
 	/**
-	 * @function deploy
+	 * @function
 	 * @description Deploy the Contract
 	 */
 	deploy = async ({ callback }) => {
@@ -130,7 +130,7 @@ class IContract {
 	};
 
 	/**
-	 * @function setNewOwner
+	 * @function
 	 * @description Set New Owner of the Contract
 	 * @param {string} address
 	 */
@@ -139,7 +139,7 @@ class IContract {
 	}
 
 	/**
-	 * @function owner
+	 * @function
 	 * @description Get Owner of the Contract
 	 * @returns {string} address
 	 */
@@ -148,7 +148,7 @@ class IContract {
 	}
 
 	/**
-	 * @function isPaused
+	 * @function
 	 * @description Get Owner of the Contract
 	 * @returns {boolean}
 	 */
@@ -157,7 +157,7 @@ class IContract {
 	}
 
 	/**
-	 * @function pauseContract
+	 * @function
 	 * @type admin
 	 * @description Pause Contract
 	 */
@@ -166,7 +166,7 @@ class IContract {
 	}
 
 	/**
-	 * @function unpauseContract
+	 * @function
 	 * @type admin
 	 * @description Unpause Contract
 	 */
@@ -177,7 +177,7 @@ class IContract {
 	/* Optional */
 
 	/**
-	 * @function removeOtherERC20Tokens
+	 * @function
 	 * @description Remove Tokens from other ERC20 Address (in case of accident)
 	 * @param {Address} tokenAddress
 	 * @param {Address} toAddress
@@ -189,7 +189,7 @@ class IContract {
 	}
 
 	/**
-	 * @function safeGuardAllTokens
+	 * @function
 	 * @description Remove all tokens for the sake of bug or problem in the smart contract, contract has to be paused first, only Admin
 	 * @param {Address} toAddress
 	 */
@@ -198,7 +198,7 @@ class IContract {
 	}
 
 	/**
-	 * @function changeTokenAddress
+	 * @function
 	 * @description Change Token Address of Application
 	 * @param {Address} newTokenAddress
 	 */
@@ -207,7 +207,7 @@ class IContract {
 	}
 
 	/**
-	 * @function getAddress
+	 * @function
 	 * @description Get Balance of Contract
 	 * @param {Integer} Balance
 	 */
@@ -216,7 +216,7 @@ class IContract {
 	}
 
 	/**
-	 * @function getBalance
+	 * @function
 	 * @description Get Balance of Contract
 	 * @param {Integer} Balance
 	 */
@@ -226,7 +226,7 @@ class IContract {
 	}
 
 	/**
-	 * @function getUserAddress
+	 * @function
 	 * @description Get contract current user/sender address
 	 * @param {Address} User address
 	 */
@@ -239,7 +239,7 @@ class IContract {
 	}
 
 	/**
-	 * @function onlyOwner
+	 * @function
 	 * @description Verify that current user/sender is admin, throws an error otherwise
 	 * @throws {Error}
 	 */
@@ -254,7 +254,7 @@ class IContract {
 	}
 
 	/**
-	 * @function whenNotPaused
+	 * @function
 	 * @description Verify that contract is not paused before sending a transaction, throws an error otherwise
 	 * @throws {Error}
 	 */


### PR DESCRIPTION
remove -v argument from `jsdoc:build`
replace `@constructor` with `@class` because `@constructor` isn't recognized
remove name from `@function` as it will create that function as a member of the global state instead of the class
remove `@overrides` because it doesn't exist