### PR TITLE
Add npm test to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+
       - name: npm install
         run: npm install
-      - name: npm build
-        run: npm run-script build
-      - name: npm run jsdoc:build
-        run: npm run-script build docs
+
+      - name: Start ganache and test solution
+        run: npm run ganache:start & npm run test
         env:
-          CI: true        
+          CI: true

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "jsdoc:serve": "http-server ./docs/ -o",
         "prebuild": "npm run jsdoc:build",
         "lint": "eslint ./src --cache",
-        "lint:fix": "eslint ./src --fix"
+        "lint:fix": "eslint ./src --fix",
+        "ganache:start": "ganache-cli -p 8545"
     },
     "pre-commit": [
         "lint",


### PR DESCRIPTION
**Bounty**
#49


**Describe the solution**
`build.yml` workflow was not starting a `ganache-cli` instance, so I added a new npm script entry `ganache:start` that does so (configured to the same port that we have on `truffle-config.js#networks.development`) and call it before starting `npm run test`.

I've also went ahead and removed the `npm run build` call because `npm run test` already does so on the `pretest` script at `package.json#scripts.pretest`


**Preview**
https://github.com/moshmage/bepro-js/runs/2579248099?check_suite_focus=true


**ETH Wallet**
Bragging rights
