### PR TITLE
postinstall script for npm install github consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "lint": "eslint ./src --cache",
         "lint:fix": "eslint ./src --fix",
         "ganache:start": "ganache-cli -p 8545",
-        "watch": "onchange 'src/**/*.js' -- npm run build"
+        "watch": "onchange 'src/**/*.js' -- npm run build",
+        "install": "( [ ! -d ./build ] && [ ! -f ./built ] && echo \"\" > ./built && npm install . && npm run build ) || echo \"Already built\""
     },
     "pre-commit": [
         "lint:fix",


### PR DESCRIPTION
**Describe the solution**
add post-install script that checks for build folder and builds the library if it doesn't find it

