### PR TITLE
Fixed emitted event on offerPack from PackOpened to Pack Bought

### DIFF
--- a/contracts/custom/OpenerRealFvr.sol
+++ b/contracts/custom/OpenerRealFvr.sol
@@ -170,8 +170,7 @@ contract OpenerRealFvr is  Ownable, ERC721 {
             registeredIDs[receivingAddress][packs[packId].initialNFTId+i] = true;
             registeredIDsArray[receivingAddress].push(i);
         }
-
-        emit PackOpened(receivingAddress, packId);
+        emit PackBought(receivingAddress, packId);
     }
 
     function editPackInfo(uint256 _packId, uint256 _saleStart, string memory serie, string memory packType, string memory drop, uint256 price) public onlyOwner {


### PR DESCRIPTION
Just did a small fix for the event emitted on offerPack from PackOpened to PackBought.